### PR TITLE
TA: Fix syntax error that causes setup script to crash

### DIFF
--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -45,7 +45,7 @@ if [ -f "teams_source/manage.py" ]; then
     python teams_source/manage.py loaddata "$f"
   done
 
-  if [! -f "venv/user_created" ]; then
+  if [ ! -f "venv/user_created" ]; then
     echo
     echo "Create an admin user"
     touch venv/user_created


### PR DESCRIPTION
Shell script crashes on MacOS and Linux because it is not POSIX compliant as it is missing necessary whitespace in an `if` statement

Fixes #43 