### PR TITLE
Add Makefile from Absence Planner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+SHELL = /bin/sh
+
+ifeq ($(OS), Windows_NT)
+all: windows
+else
+all: unix
+endif
+
+windows:
+	.\setup.bat
+
+unix:
+	./setup.sh


### PR DESCRIPTION
If you want to test the `Makefile`, follow the [instructions in the developer guide](https://github.com/rropen/absense-planner/blob/develop/DEVELOPER.md#gnu-make).